### PR TITLE
Sc 43289/globe life unable to pull export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
-benchmark/node_modules
 
 .DS_Store
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.1.0] - 2024-04-03
+## Update
+- `life` as a valid top-level domain for email format validation
+- include `life` as part of tox tests
+- update tox tests to use python3
+- bump mocha to ^10.4.0; update npm test script accordingly
+
+## [1.0.1] - 2024-03-11
+## Bump
+- uglify-js to ^2.6
+
+## [1.0.0] - 2024-03-11
+## Fork
+- initial fork of themis@v1.1.6
+- no updates in 9 years from publisher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.0] - 2024-04-03
 ## Update
 - `life` as a valid top-level domain for email format validation
-- include `life` as part of tox tests
-- update tox tests to use python3
 - bump mocha to ^10.4.0; update npm test script accordingly
 
 ## [1.0.1] - 2024-03-11

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A blazing fast JSON Schema v4 validator",
   "main": "src/themis.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -R spec"
+    "test": "mocha -R spec"
   },
   "keywords": [
     "json",
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "chai": "^1.9.2",
-    "mocha": "^2.0.1"
+    "mocha": "^10.4.0"
   },
   "author": "Johny Jose <johny@playlyfe.com>",
   "license": "MIT",

--- a/src/themis.js
+++ b/src/themis.js
@@ -481,7 +481,7 @@ var Utils = {
             return true;
         }
         // http://emailregex.com/
-        return /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i.test(email);
+        return /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|life|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i.test(email);
     },
     "hostname": function (hostname) {
         if (typeof hostname !== "string") {


### PR DESCRIPTION
## Description of the change

> Update to allow `life` as top-level domain; bump mocha to v10.4.0

Up on Dev if there is anyone with a `.life` email address who can test.

Verified that `life` is allowed locally with linked repo in leadconduit-api; added unit test there.

![Screenshot 2024-04-04 at 3 15 35 PM](https://github.com/activeprospect/themis/assets/13036323/ca1c6360-b373-47a8-907b-4726d2161935)


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/43289/globe-life-unable-to-pull-export

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [x]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
