### PR TITLE
Move email format test from lc-api export test

### DIFF
--- a/test/pattern.js
+++ b/test/pattern.js
@@ -1,6 +1,6 @@
 Themis = require('../src/themis');
 
-describe.only('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', function() {
+describe('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', function() {
 
   it('should be able to dereference fragments of external schemas', function() {
     var schemas = [

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -1,6 +1,6 @@
 Themis = require('../src/themis');
 
-describe('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', function() {
+describe.only('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', function() {
 
   it('should be able to dereference fragments of external schemas', function() {
     var schemas = [
@@ -34,6 +34,83 @@ describe('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', 
     };
     validator(invalid_item, 'kitchensink').valid.should.be.false;
     validator(valid_item, 'kitchensink').valid.should.be.true;
+  });
+
+  it('should validate emails correctly', function() {
+    var schemas = [
+      {
+        "id": "types",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "definitions": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        }
+      },
+      {
+        "id": "kitchensink",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "email": { "$ref": "types#/definitions/email" }
+        }
+      }
+    ];
+
+    var validator = Themis.validator(schemas);
+
+    var valid_emails = [
+      "simple@example.com",
+      "very.common@example.com",
+      "disposable.style.email.with+symbol@example.com",
+      "other.email-with-dash@example.com",
+      "x@example.com",
+      "example-indeed@strange-example.com",
+      "user@domain.aero",
+      "user@domain.arpa",
+      "user@domain.biz",
+      "user@domain.com",
+      "user@domain.coop",
+      "user@domain.edu",
+      "user@domain.gov",
+      "user@domain.info",
+      "user@domain.int",
+      "user@domain.life",
+      "user@domain.mil",
+      "user@domain.museum",
+      "user@domain.name",
+      "user@domain.net",
+      "user@domain.org",
+      "user@domain.pro",
+      "user@domain.travel",
+      "user@domain.mobi",
+      "user@domain.xx"
+    ];
+
+    var invalid_emails = [
+      "plainaddress",
+      "@missingusername.com",
+      "username@.com",
+      "username@.com.",
+      "username@com",
+      "username@.com.com",
+      ".username@yahoo.com",
+      "username@yahoo.com.",
+      "username@yahoo..com",
+      "username@-yahoo.com",
+      "user@domain.toolongtld" // Invalid TLD
+    ];
+
+    valid_emails.forEach(email => {
+      var valid_item = { "email": email };
+      expect(validator(valid_item, 'kitchensink').valid).to.be.true;
+    });
+
+    invalid_emails.forEach(email => {
+      var invalid_item = { "email": email };
+      expect(validator(invalid_item, 'kitchensink').valid).to.be.false;
+    });
   });
 
 });


### PR DESCRIPTION
## Description of the change

Moved the email format validation test from `leadconduit-api` (export test-legacy) to this repository. The `lc-api` export will now only include email tests related to email address ownership, as the JSON schema email format validation logic is handled here.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

[Ticket](https://app.shortcut.com/active-prospect/story/72936/improper-validation-of-email-to-parameter-when-exporting-lead-events)

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [X]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
