### PR TITLE
Sc 47498/certain users unable to complete lead export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-
 name: Node.js CI
 on: push
 jobs:
@@ -6,19 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
-        mongodb-version: [4.0]
+        node-version: [18.x, 20.x, latest]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - name: Run tests
       run: npx nyc@latest --reporter=lcov npm test
-    - uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/src/themis.js
+++ b/src/themis.js
@@ -480,8 +480,8 @@ var Utils = {
         if (typeof email !== "string") {
             return true;
         }
-        // http://emailregex.com/
-        return /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|life|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i.test(email);
+        // copied from http://emailregex.com/
+        return /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email);
     },
     "hostname": function (hostname) {
         if (typeof hostname !== "string") {

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -97,9 +97,7 @@ describe('Issue #3: Crashing when pattern is incorrect in ref(erenced) schema', 
       "username@.com.com",
       ".username@yahoo.com",
       "username@yahoo.com.",
-      "username@yahoo..com",
-      "username@-yahoo.com",
-      "user@domain.toolongtld" // Invalid TLD
+      "username@yahoo..com"
     ];
 
     valid_emails.forEach(email => {


### PR DESCRIPTION
## Description of the change

Update email validation to allow more TLDs. This is based on an updated regex from emailregex.com. It's more permissive, but where this is applied (exports configuration), LC is already verifying that the delivery email belongs to a user in the AP account. In other words, the validity has already been ensured during signup.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/47498/certain-users-unable-to-complete-lead-export

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
